### PR TITLE
Feat/el10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ RPMS
 .docker
 *DS_Store
 *.rpm
+.idea

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,16 @@ VERSION := $(if $(VERSION),$(VERSION),${MAINVERSION}.0)
 SUDO := $(if $(filter 1,$(NO_SUDO)),,sudo)
 
 # Основные зависимости
-BASE_DEPS := pcre-devel pcre2-devel make gcc openssl-devel rpm-build systemd-devel curl sed zlib-devel
+BASE_DEPS := make gcc openssl-devel rpm-build systemd-devel curl sed zlib-devel
+
+# Detect RHEL version to select correct PCRE library
+RHEL_VER := $(shell rpm -E %{rhel} 2>/dev/null)
+ifeq ($(shell [ -n "$(RHEL_VER)" ] && [ "$(RHEL_VER)" -ge 8 ] 2>/dev/null && echo 1 || echo 0),1)
+    BASE_DEPS += pcre2-devel
+else
+    BASE_DEPS += pcre-devel
+endif
+
 LUA_DEPS := readline-devel
 
 # Этапы сборки

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,9 @@ SUDO := $(if $(filter 1,$(NO_SUDO)),,sudo)
 # Основные зависимости
 BASE_DEPS := make gcc openssl-devel rpm-build systemd-devel curl sed zlib-devel
 
-# Detect RHEL version to select correct PCRE library
-RHEL_VER := $(shell rpm -E %{rhel} 2>/dev/null)
-ifeq ($(shell [ -n "$(RHEL_VER)" ] && [ "$(RHEL_VER)" -ge 8 ] 2>/dev/null && echo 1 || echo 0),1)
+# Detect distro to select correct PCRE library (PCRE2 for EL8+/AMZN2023)
+DIST := $(shell rpm -E %{dist} 2>/dev/null)
+ifneq ($(filter .el8 .el9 .el10 .amzn2023,$(DIST)),)
     BASE_DEPS += pcre2-devel
 else
     BASE_DEPS += pcre-devel

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RPM builder for HAProxy 3.2 (CentOS 8/9)
+# RPM builder for HAProxy 3.2 (EL8/EL9/EL10/Amazon Linux 2023)
 ## Build latest HAProxy binary with prometheus metrics support
 
 ![GitHub last commit](https://img.shields.io/github/last-commit/philyuchkoff/HAProxy-3-RPM-builder?style=for-the-badge)
@@ -81,8 +81,15 @@ If SELINUX is enabled  - switch off this: open /etc/selinux/config and change SE
 - Create `/var/lib/haproxy` directory
 - Check on the rpcbind service to ensure that this service is started 
 
-#### :o: Failed to download metadata for repo ‘AppStream’ (CentOS8/9)
+#### :o: Failed to download metadata for repo 'AppStream' (CentOS8/9)
 ##### Solution:
     cd /etc/yum.repos.d/
     sudo sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
     sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
+
+### Supported platforms:
+- Enterprise Linux 8 (RHEL 8, CentOS 8, Rocky Linux 8, AlmaLinux 8)
+- Enterprise Linux 9 (RHEL 9, CentOS 9, Rocky Linux 9, AlmaLinux 9)
+- Enterprise Linux 10 (RHEL 10, CentOS 10, Rocky Linux 10, AlmaLinux 10)
+- Amazon Linux 2023

--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ If SELINUX is enabled  - switch off this: open /etc/selinux/config and change SE
     sudo sed -i s/^SELINUX=.*$/SELINUX=disabled/ /etc/selinux/config
 
 
+#### :o: Work with non-standard ports (SELinux)
+
+    sudo dnf -yd install policycoreutils-python-utils
+    sudo semanage port -a -t http_port_t -p tcp 9999
+
+
 #### :o: Cannot chroot1
     [/usr/sbin/haproxy.main()] Cannot chroot1(/var/lib/haproxy)  
 ##### Solution:

--- a/README.md
+++ b/README.md
@@ -96,3 +96,17 @@ If SELINUX is enabled  - switch off this: open /etc/selinux/config and change SE
 - Enterprise Linux 9 (RHEL 9, CentOS 9, Rocky Linux 9, AlmaLinux 9)
 - Enterprise Linux 10 (RHEL 10, CentOS 10, Rocky Linux 10, AlmaLinux 10)
 - Amazon Linux 2023
+
+### ⚠️ Breaking changes
+
+#### Stats socket path changed
+The default `stats socket` path in `haproxy.cfg` was changed from `/run/haproxy/haproxy.sock` to `/run/haproxy.sock` (removed the `/run/haproxy/` subdirectory so no extra directory creation is needed).
+
+**Migration**: If you have monitoring scripts, `socat` commands, or external tools referencing the old path, update them to the new path:
+
+```diff
+- /run/haproxy/haproxy.sock
++ /run/haproxy.sock
+```
+
+Or override the path in your own `haproxy.cfg` to keep the previous value.

--- a/SOURCES/haproxy.cfg
+++ b/SOURCES/haproxy.cfg
@@ -7,7 +7,7 @@ global
     #log /dev/log    local1 notice
     log 127.0.0.1 local1 notice
     chroot /var/lib/haproxy
-    stats socket /run/haproxy/haproxy.sock mode 600 level admin
+    stats socket /run/haproxy.sock mode 600 level admin
     pidfile /var/run/haproxy.pid
     stats timeout 30s
     user haproxy
@@ -20,7 +20,10 @@ listen stats
   stats enable
   stats realm Haproxy\ Statistics  # Title text for popup window
   stats uri /haproxy_stats
-
+  timeout connect 5s
+  timeout client  10s
+  timeout server  10s
+    
 defaults
     log     global
     mode    http

--- a/SOURCES/haproxy.cfg
+++ b/SOURCES/haproxy.cfg
@@ -3,9 +3,9 @@
 #
 global
     #log /dev/log    local0
-    log 127.0.0.1 local0
-    #log /dev/log    local1 notice
-    log 127.0.0.1 local1 notice
+    log 127.0.0.1    local2
+    #log /dev/log     local1 notice
+    #log 127.0.0.1    local1 notice
     chroot /var/lib/haproxy
     stats socket /run/haproxy.sock mode 600 level admin
     pidfile /var/run/haproxy.pid

--- a/SOURCES/haproxy.cfg
+++ b/SOURCES/haproxy.cfg
@@ -1,6 +1,9 @@
 #
 # THIS IS SAMPLE CONFIG, FOR TEST, NOT FOR PRODUCTION!!!
 #
+# To check config run:
+# haproxy -c -V -f /etc/haproxy/haproxy.cfg
+
 global
     #log /dev/log    local0
     log 127.0.0.1    local2
@@ -8,22 +11,26 @@ global
     #log 127.0.0.1    local1 notice
     chroot /var/lib/haproxy
     stats socket /run/haproxy.sock mode 600 level admin
-    pidfile /var/run/haproxy.pid
+    #pidfile /var/run/haproxy.pid
     stats timeout 30s
     user haproxy
     group haproxy
     daemon
-    
+
 listen stats
   bind :9000
   mode http
+  #http-request use-service prometheus-exporter if { path /metrics }
   stats enable
+  #stats hide-version
+  stats refresh 10s
   stats realm Haproxy\ Statistics  # Title text for popup window
   stats uri /haproxy_stats
+  #stats auth admin:admin_password
   timeout connect 5s
   timeout client  10s
   timeout server  10s
-    
+
 defaults
     log     global
     mode    http

--- a/SOURCES/haproxy.cfg
+++ b/SOURCES/haproxy.cfg
@@ -6,7 +6,7 @@
 
 global
     #log /dev/log    local0
-    log 127.0.0.1    local2
+    log 127.0.0.1    local0
     #log /dev/log     local1 notice
     #log 127.0.0.1    local1 notice
     chroot /var/lib/haproxy

--- a/SOURCES/haproxy.syslog.amzn2023
+++ b/SOURCES/haproxy.syslog.amzn2023
@@ -1,22 +1,21 @@
-# /opt/HAProxy-3-RPM-builder/rpmbuild/SOURCES/haproxy.syslog.amzn2023
-# Syslog configuration for HAProxy on Amazon Linux 2023 (using rsyslog)
+$ModLoad imudp
+$UDPServerAddress 127.0.0.1
+$UDPServerRun 514
 
-# Enable UDP reception (for older syslog protocols)
-module(load="imudp")
-input(type="imudp" port="514")
+$template HAProxy,"%TIMESTAMP% %syslogseverity-text:::UPPERCASE%: %msg:::drop-last-lf%\n"
+$template HAProxyAccess,"%msg%\n"
 
-# Enable TCP reception (more reliable)
-module(load="imtcp")
-input(type="imtcp" port="514")
-
-# HAProxy logging configuration
-local0.*    /var/log/haproxy.log
-& ~
-
-# Optional: Send HAProxy logs to a remote syslog server
-# Replace with your actual remote server IP
-# local0.* @@remote-syslog-server:514
-
-# Template for structured logging (optional)
-template(name="haproxy-template" type="string"
-         string="%timestamp% %hostname% %syslogtag%%msg%")
+if $programname startswith 'haproxy' then {
+  if $syslogseverity == 6 then {
+      action(type="omfile" file="/var/log/haproxy/access.log" template="HAProxyAccess")
+      stop
+  }
+  if $syslogseverity <= 3 then {
+      action(type="omfile" file="/var/log/haproxy/error.log" template="HAProxy")
+      stop
+  }
+  if $syslogseverity <= 5 then {
+      action(type="omfile" file="/var/log/haproxy/status.log" template="HAProxy")
+      stop
+  }
+}

--- a/SOURCES/haproxy.syslog.el10
+++ b/SOURCES/haproxy.syslog.el10
@@ -1,0 +1,18 @@
+$ModLoad imudp
+$UDPServerAddress 127.0.0.1
+$UDPServerRun 514
+
+$template HAProxy,"%TIMESTAMP% %syslogseverity-text:::UPPERCASE%: %msg:::drop-last-lf%\n"
+$template HAProxyAccess,"%msg%\n"
+
+if $programname startswith 'haproxy' then {
+  if $syslogseverity == 6 then
+      action(type="omfile" file="/var/log/haproxy/access.log" template="HAProxyAccess")
+      stop
+  if $syslogseverity <= 3 then
+      action(type="omfile" file="/var/log/haproxy/error.log" template="HAProxy")
+      stop
+  if $syslogseverity <= 5 then
+      action(type="omfile" file="/var/log/haproxy/status.log" template="HAProxy")
+      stop
+}

--- a/SOURCES/haproxy.syslog.el10
+++ b/SOURCES/haproxy.syslog.el10
@@ -6,13 +6,16 @@ $template HAProxy,"%TIMESTAMP% %syslogseverity-text:::UPPERCASE%: %msg:::drop-la
 $template HAProxyAccess,"%msg%\n"
 
 if $programname startswith 'haproxy' then {
-  if $syslogseverity == 6 then
+  if $syslogseverity == 6 then {
       action(type="omfile" file="/var/log/haproxy/access.log" template="HAProxyAccess")
       stop
-  if $syslogseverity <= 3 then
+  }
+  if $syslogseverity <= 3 then {
       action(type="omfile" file="/var/log/haproxy/error.log" template="HAProxy")
       stop
-  if $syslogseverity <= 5 then
+  }
+  if $syslogseverity <= 5 then {
       action(type="omfile" file="/var/log/haproxy/status.log" template="HAProxy")
       stop
+  }
 }

--- a/SOURCES/haproxy.syslog.el6
+++ b/SOURCES/haproxy.syslog.el6
@@ -1,0 +1,13 @@
+$ModLoad imudp
+$UDPServerAddress 127.0.0.1
+$UDPServerRun 514
+$MaxMessageSize 64k
+$FileCreateMode 0600
+
+$template HAProxy,"%TIMESTAMP% %syslogseverity-text:::UPPERCASE%: %msg%\n"
+$template HAProxyAccess,"%msg%\n"
+
+local2.=info     /var/log/haproxy/access.log;HAProxyAccess
+local2.=notice;local2.=warning    /var/log/haproxy/status.log;HAProxy
+local2.error    /var/log/haproxy/error.log;HAProxy
+local2.* ~

--- a/SOURCES/haproxy.syslog.el7
+++ b/SOURCES/haproxy.syslog.el7
@@ -1,0 +1,13 @@
+$ModLoad imudp
+$UDPServerAddress 127.0.0.1
+$UDPServerRun 514
+$MaxMessageSize 64k
+$FileCreateMode 0600
+
+$template HAProxy,"%TIMESTAMP% %syslogseverity-text:::UPPERCASE%: %msg%\n"
+$template HAProxyAccess,"%msg%\n"
+
+local2.=info     /var/log/haproxy/access.log;HAProxyAccess
+local2.=notice;local2.=warning    /var/log/haproxy/status.log;HAProxy
+local2.error    /var/log/haproxy/error.log;HAProxy
+local2.* stop

--- a/SOURCES/haproxy.syslog.el8
+++ b/SOURCES/haproxy.syslog.el8
@@ -5,9 +5,17 @@ $UDPServerRun 514
 $template HAProxy,"%TIMESTAMP% %syslogseverity-text:::UPPERCASE%: %msg:::drop-last-lf%\n"
 $template HAProxyAccess,"%msg%\n"
 
-local2.=info if $programname startswith 'haproxy' then /var/log/haproxy/access.log;HAProxyAccess 
-& stop
-local2.emerg if $programname startswith 'haproxy' then /var/log/haproxy/error.log;HAProxy
-& stop
-local2.notice if $programname startswith 'haproxy' then /var/log/haproxy/status.log;HAProxy
-& stop
+if $programname startswith 'haproxy' then {
+  if $syslogseverity == 6 then {
+      action(type="omfile" file="/var/log/haproxy/access.log" template="HAProxyAccess")
+      stop
+  }
+  if $syslogseverity <= 3 then {
+      action(type="omfile" file="/var/log/haproxy/error.log" template="HAProxy")
+      stop
+  }
+  if $syslogseverity <= 5 then {
+      action(type="omfile" file="/var/log/haproxy/status.log" template="HAProxy")
+      stop
+  }
+}

--- a/SOURCES/haproxy.syslog.el9
+++ b/SOURCES/haproxy.syslog.el9
@@ -6,13 +6,16 @@ $template HAProxy,"%TIMESTAMP% %syslogseverity-text:::UPPERCASE%: %msg:::drop-la
 $template HAProxyAccess,"%msg%\n"
 
 if $programname startswith 'haproxy' then {
-  if $syslogseverity == 6 then
+  if $syslogseverity == 6 then {
       action(type="omfile" file="/var/log/haproxy/access.log" template="HAProxyAccess")
       stop
-  if $syslogseverity <= 3 then
+  }
+  if $syslogseverity <= 3 then {
       action(type="omfile" file="/var/log/haproxy/error.log" template="HAProxy")
       stop
-  if $syslogseverity <= 5 then
+  }
+  if $syslogseverity <= 5 then {
       action(type="omfile" file="/var/log/haproxy/status.log" template="HAProxy")
       stop
+  }
 }

--- a/SPECS/haproxy.spec
+++ b/SPECS/haproxy.spec
@@ -32,7 +32,7 @@ Source5: halog.1
 BuildRoot: %{_tmppath}/%{name}-%{version}-root
 
 # PCRE selection: EL8, EL9, and EL10 use PCRE2. EL6/7 use PCRE1.
-%if 0%{?rhel} >= 8
+%if 0%{?rhel} >= 8 || 0%{?amzn2023}
 BuildRequires: pcre2-devel
 %else
 BuildRequires: pcre-devel
@@ -53,7 +53,7 @@ Requires(postun):   initscripts
 %endif
 
 # Systemd dependencies for EL7+ (including EL10)
-%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9} || 0%{?el10}
+%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9} || 0%{?el10} || 0%{?amzn2023}
 BuildRequires:      systemd
 Requires(post):     systemd
 Requires(preun):    systemd
@@ -91,7 +91,7 @@ USE_TFO=
 USE_NS=
 
 # PCRE2 flags for EL8+
-%if 0%{?rhel} >= 8
+%if 0%{?rhel} >= 8 || 0%{?amzn2023}
 pcre_opts="USE_PCRE2=1 USE_PCRE2_JIT=1"
 %else
 # PCRE1 flags for EL7/6
@@ -99,7 +99,7 @@ pcre_opts="USE_PCRE=1 USE_PCRE_JIT=1"
 %endif
 
 # TFO and NS support for EL7+
-%if 0%{?el7} || 0%{?el8} || 0%{?el9} || 0%{?el10}
+%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9} || 0%{?el10} || 0%{?amzn2023}
 USE_TFO=1
 USE_NS=1
 %endif
@@ -158,7 +158,7 @@ popd
 %{__install} -c -m 755 %{SOURCE2} %{buildroot}%{_sysconfdir}/rc.d/init.d/%{name}
 %endif
 
-%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9} || 0%{?el10}
+%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9} || 0%{?el10} || 0%{?amzn2023}
 %{__install} -p -D -m 0644 %{SOURCE2} %{buildroot}%{_unitdir}/%{name}.service
 %endif
 
@@ -174,7 +174,7 @@ getent passwd %{haproxy_user} >/dev/null || \
 exit 0
 
 %post
-%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9} || 0%{?el10}
+%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9} || 0%{?el10} || 0%{?amzn2023}
 %systemd_post %{name}.service
 systemctl reload-or-try-restart rsyslog.service
 %endif
@@ -185,7 +185,7 @@ systemctl reload-or-try-restart rsyslog.service
 %endif
 
 %preun
-%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9} || 0%{?el10}
+%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9} || 0%{?el10} || 0%{?amzn2023}
 %systemd_preun %{name}.service
 %endif
 
@@ -197,7 +197,7 @@ fi
 %endif
 
 %postun
-%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9} || 0%{?el10}
+%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9} || 0%{?el10} || 0%{?amzn2023}
 %systemd_postun_with_restart %{name}.service
 systemctl reload-or-try-restart rsyslog.service
 %endif
@@ -212,7 +212,7 @@ fi
 %files
 %defattr(-,root,root)
 %doc CHANGELOG examples/*.cfg doc/configuration.txt doc/intro.txt doc/management.txt doc/proxy-protocol.txt
-%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9} || 0%{?el10}
+%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9} || 0%{?el10} || 0%{?amzn2023}
     %license LICENSE
 %endif
 %doc %{_mandir}/man1/*
@@ -231,6 +231,6 @@ fi
 %attr(0755,root,root) %config %_sysconfdir/rc.d/init.d/%{name}
 %endif
 
-%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9} || 0%{?el10}
+%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9} || 0%{?el10} || 0%{?amzn2023}
 %attr(-,root,root) %{_unitdir}/%{name}.service
 %endif

--- a/SPECS/haproxy.spec
+++ b/SPECS/haproxy.spec
@@ -31,7 +31,12 @@ Source4: %{name}.syslog%{?dist}
 Source5: halog.1
 BuildRoot: %{_tmppath}/%{name}-%{version}-root
 
+%if 0%{?el10}
+BuildRequires: pcre2-devel
+%else
 BuildRequires: pcre-devel
+%endif
+
 BuildRequires: zlib-devel
 BuildRequires: make
 BuildRequires: gcc openssl-devel
@@ -49,6 +54,13 @@ Requires(postun):   initscripts
 %if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9}
 BuildRequires:      systemd-units
 BuildRequires:      systemd-devel
+Requires(post):     systemd
+Requires(preun):    systemd
+Requires(postun):   systemd
+%endif
+
+%if 0%{?el10}
+BuildRequires:      systemd
 Requires(post):     systemd
 Requires(preun):    systemd
 Requires(postun):   systemd
@@ -79,7 +91,7 @@ https://github.com/philyuchkoff/HAProxy-3-RPM-builder
 %build
 regparm_opts=
 %ifarch %ix86 x86_64
-regparm_opts="USE_REGPARM=1"
+#regparm_opts="USE_REGPARM=1"
 %endif
 
 RPM_BUILD_NCPUS="`/usr/bin/nproc 2>/dev/null || /usr/bin/getconf _NPROCESSORS_ONLN`";
@@ -95,7 +107,11 @@ systemd_opts="USE_SYSTEMD=1"
 pcre_opts="USE_PCRE=1 USE_PCRE_JIT=1"
 %endif
 
-%if 0%{?el7} || 0%{?el8} || 0%{?el9}
+%if 0%{?el10}
+pcre_opts="USE_PCRE2=1 USE_PCRE2_JIT=1"
+%endif
+
+%if 0%{?el7} || 0%{?el8} || 0%{?el9} || 0%{?el10}
 USE_TFO=1
 USE_NS=1
 %endif
@@ -127,8 +143,9 @@ popd
 %{__install} -d %{buildroot}%{_sysconfdir}/logrotate.d
 %{__install} -d %{buildroot}%{_sysconfdir}/rsyslog.d
 %{__install} -d %{buildroot}%{_localstatedir}/log/%{name}
+%{__install} -d %{buildroot}%{_localstatedir}/lib/%{name}
 
-%{__install} -s %{name} %{buildroot}%{_sbindir}/
+%{__install} %{name} %{buildroot}%{_sbindir}/
 
 
 %{__install} -c -m 644 %{SOURCE1} %{buildroot}%{_sysconfdir}/%{name}/haproxy.cfg
@@ -146,8 +163,8 @@ popd
 %{__install} -c -m 755 %{SOURCE2} %{buildroot}%{_sysconfdir}/rc.d/init.d/%{name}
 %endif
 
-%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9}
-%{__install} -s %{name} %{buildroot}%{_sbindir}/
+%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9} || 0%{?el10}
+%{__install} %{name} %{buildroot}%{_sbindir}/
 %{__install} -p -D -m 0644 %{SOURCE2} %{buildroot}%{_unitdir}/%{name}.service
 %endif
 
@@ -163,7 +180,7 @@ getent passwd %{haproxy_user} >/dev/null || \
 exit 0
 
 %post
-%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9}
+%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9} || 0%{?el10}
 %systemd_post %{name}.service
 systemctl reload-or-try-restart rsyslog.service
 %endif
@@ -174,7 +191,7 @@ systemctl reload-or-try-restart rsyslog.service
 %endif
 
 %preun
-%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9}
+%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9} || 0%{?el10}
 %systemd_preun %{name}.service
 %endif
 
@@ -186,7 +203,7 @@ fi
 %endif
 
 %postun
-%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9}
+%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9} || 0%{?el10}
 %systemd_postun_with_restart %{name}.service
 systemctl reload-or-try-restart rsyslog.service
 %endif
@@ -201,7 +218,7 @@ fi
 %files
 %defattr(-,root,root)
 %doc CHANGELOG examples/*.cfg doc/configuration.txt doc/intro.txt doc/management.txt doc/proxy-protocol.txt
-%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9}
+%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9} || 0%{?el10}
     %license LICENSE
 %endif
 %doc %{_mandir}/man1/*
@@ -210,6 +227,7 @@ fi
 %attr(0644,root,root) %config(noreplace) %{_sysconfdir}/%{name}/%{name}.cfg
 %attr(0755,root,root) %{_sbindir}/%{name}
 %dir %{_localstatedir}/log/%{name}
+%dir %{_localstatedir}/lib/%{name}
 %attr(0644,root,root) %config(noreplace) %{_sysconfdir}/logrotate.d/%{name}
 %attr(0644,root,root) %config(noreplace) %{_sysconfdir}/rsyslog.d/49-%{name}.conf
 %{_bindir}/halog
@@ -219,6 +237,6 @@ fi
 %attr(0755,root,root) %config %_sysconfdir/rc.d/init.d/%{name}
 %endif
 
-%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9}
+%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9} || 0%{?el10}
 %attr(-,root,root) %{_unitdir}/%{name}.service
 %endif

--- a/SPECS/haproxy.spec
+++ b/SPECS/haproxy.spec
@@ -31,7 +31,8 @@ Source4: %{name}.syslog%{?dist}
 Source5: halog.1
 BuildRoot: %{_tmppath}/%{name}-%{version}-root
 
-%if 0%{?el10}
+# PCRE selection: EL8, EL9, and EL10 use PCRE2. EL6/7 use PCRE1.
+%if 0%{?rhel} >= 8
 BuildRequires: pcre2-devel
 %else
 BuildRequires: pcre-devel
@@ -39,7 +40,7 @@ BuildRequires: pcre-devel
 
 BuildRequires: zlib-devel
 BuildRequires: make
-BuildRequires: gcc openssl-devel
+BuildRequires: gcc
 BuildRequires: openssl-devel
 
 Requires(pre):      shadow-utils
@@ -51,15 +52,8 @@ Requires(preun):    chkconfig, initscripts
 Requires(postun):   initscripts
 %endif
 
-%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9}
-BuildRequires:      systemd-units
-BuildRequires:      systemd-devel
-Requires(post):     systemd
-Requires(preun):    systemd
-Requires(postun):   systemd
-%endif
-
-%if 0%{?el10}
+# Systemd dependencies for EL7+ (including EL10)
+%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9} || 0%{?el10}
 BuildRequires:      systemd
 Requires(post):     systemd
 Requires(preun):    systemd
@@ -85,32 +79,26 @@ https://github.com/philyuchkoff/HAProxy-3-RPM-builder
 %prep
 %setup -q
 
-# We don't want any perl dependecies in this RPM:
+# We don't want any perl dependencies in this RPM:
 %define __perl_requires /bin/true
 
 %build
-regparm_opts=
-%ifarch %ix86 x86_64
-#regparm_opts="USE_REGPARM=1"
-%endif
-
 RPM_BUILD_NCPUS="`/usr/bin/nproc 2>/dev/null || /usr/bin/getconf _NPROCESSORS_ONLN`";
 
 # Default opts
-systemd_opts=
 pcre_opts="USE_PCRE=1"
 USE_TFO=
 USE_NS=
 
-%if 0%{?el7} || 0%{?el8} || 0%{?el9}
-systemd_opts="USE_SYSTEMD=1"
+# PCRE2 flags for EL8+
+%if 0%{?rhel} >= 8
+pcre_opts="USE_PCRE2=1 USE_PCRE2_JIT=1"
+%else
+# PCRE1 flags for EL7/6
 pcre_opts="USE_PCRE=1 USE_PCRE_JIT=1"
 %endif
 
-%if 0%{?el10}
-pcre_opts="USE_PCRE2=1 USE_PCRE2_JIT=1"
-%endif
-
+# TFO and NS support for EL7+
 %if 0%{?el7} || 0%{?el8} || 0%{?el9} || 0%{?el10}
 USE_TFO=1
 USE_NS=1
@@ -124,7 +112,14 @@ SET_LUA="USE_LUA=1"
 SET_PROMETHEUS="EXTRA_OBJS=addons/promex/service-prometheus.o"
 %endif
 
-%{__make} -j$RPM_BUILD_NCPUS %{?_smp_mflags} CPU="generic" TARGET="linux-glibc" ${systemd_opts} ${pcre_opts} USE_OPENSSL=1 USE_ZLIB=1 USE_PROMEX=1 ${regparm_opts} ADDINC="%{optflags}" USE_LINUX_TPROXY=1 USE_THREAD=1 USE_TFO=${USE_TFO} USE_NS=${USE_NS} ${SET_LUA} ${SET_PROMETHEUS} ADDLIB="%{__global_ldflags}"
+%{__make} -j$RPM_BUILD_NCPUS %{?_smp_mflags} CPU="generic" TARGET="linux-glibc" \
+    ${pcre_opts} \
+    USE_OPENSSL=1 USE_ZLIB=1 USE_PROMEX=1 \
+    ADDINC="%{optflags}" \
+    USE_LINUX_TPROXY=1 USE_THREAD=1 \
+    USE_TFO=${USE_TFO} USE_NS=${USE_NS} \
+    ${SET_LUA} ${SET_PROMETHEUS} \
+    ADDLIB="%{__global_ldflags}"
 
 %{__make} admin/halog/halog OPTIMIZE="%{optflags} %{__global_ldflags}"
 
@@ -145,8 +140,8 @@ popd
 %{__install} -d %{buildroot}%{_localstatedir}/log/%{name}
 %{__install} -d %{buildroot}%{_localstatedir}/lib/%{name}
 
+# Install binary once (previously duplicated)
 %{__install} %{name} %{buildroot}%{_sbindir}/
-
 
 %{__install} -c -m 644 %{SOURCE1} %{buildroot}%{_sysconfdir}/%{name}/haproxy.cfg
 %{__install} -c -m 644 examples/errorfiles/*.http %{buildroot}%{_sysconfdir}/%{name}/errors/
@@ -164,7 +159,6 @@ popd
 %endif
 
 %if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9} || 0%{?el10}
-%{__install} %{name} %{buildroot}%{_sbindir}/
 %{__install} -p -D -m 0644 %{SOURCE2} %{buildroot}%{_unitdir}/%{name}.service
 %endif
 

--- a/SPECS/haproxy.spec
+++ b/SPECS/haproxy.spec
@@ -52,9 +52,8 @@ Requires(preun):    chkconfig, initscripts
 Requires(postun):   initscripts
 %endif
 
-# Systemd dependencies for EL7+ (including EL10)
+# Systemd scriptlet deps for EL7+ (including EL10)
 %if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9} || 0%{?el10} || 0%{?amzn2023}
-BuildRequires:      systemd
 Requires(post):     systemd
 Requires(preun):    systemd
 Requires(postun):   systemd
@@ -199,13 +198,11 @@ fi
 %postun
 %if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9} || 0%{?el10} || 0%{?amzn2023}
 %systemd_postun_with_restart %{name}.service
-systemctl reload-or-try-restart rsyslog.service
 %endif
 
 %if 0%{?el6} || 0%{?amzn1}
 if [ "$1" -ge "1" ]; then
   /sbin/service %{name} condrestart >/dev/null 2>&1 || :
-  /sbin/service rsyslog restart >/dev/null 2>&1 || :
 fi
 %endif
 


### PR DESCRIPTION
- added || 0%{?el10} to BuildRequires, %install, %post, %preun, %postun, and %files.
- included %{__install} -d .../lib/%{name} and %dir .../lib/%{name}, which fixes the Cannot chroot alert.
- switch between pcre2-devel (for EL8/9/10) and pcre-devel (for older versions).
- removed the -s flag from the install command, allowing standard debuginfo generation.
- removed the obsolete USE_SYSTEMD and USE_REGPARM flags.
- fixed Amazon Linux 2023 Support
- syslog configuration logic is consistent across all systems
